### PR TITLE
Set background color to white.

### DIFF
--- a/amCoffee/style/main.css
+++ b/amCoffee/style/main.css
@@ -13,6 +13,7 @@ body {
     line-height: 1.4em;
     font-family: Consolas, Lucida Console, monospace;
     box-sizing: border-box;
+    background-color: white;
 }
 input, textarea, pre {
     font-size: 12px;


### PR DESCRIPTION
When using a devtools theme, the background color will be changed while the text doesn't. A dark theme will make the console difficult to read.

![2014-04-29 11 42 29](https://cloud.githubusercontent.com/assets/3784687/2825578/ed6afe98-cf51-11e3-89c5-78dcea3679a3.png)
